### PR TITLE
Making library usable in extension targets

### DIFF
--- a/TOPasscodeViewController/TOPasscodeSettingsViewController.m
+++ b/TOPasscodeViewController/TOPasscodeSettingsViewController.m
@@ -506,7 +506,7 @@ const CGFloat kTOPasscodeKeypadMaxHeight = 330.0f;
     }
 
     // Work out where our view is in relation to the screen
-    UIWindow *window = [UIApplication sharedApplication].keyWindow;
+    UIWindow *window = self.view.window;
     CGRect viewFrame = [self.view.superview convertRect:self.view.frame toView:window];
 
     CGFloat overlap = CGRectGetMaxY(viewFrame) - CGRectGetMinY(self.keyboardFrame);


### PR DESCRIPTION
Hi, this PR removes usage of UIApplication`s sharedApplication method to make library usable in extensions targets. (described in #5)

I've run tests and did manual testing for all this cases so nothing should be broken:

- [x] Presenting and dismissing the view controller in both portrait and landscape modes.
- [x] Presenting the view controller, rotating the device and then dismissing from the new orientation.
- [x] Presenting the view controller, then enabling split-screen on an iPad.
- [x] Changing the split-screen window sizes on iPad.