### PR TITLE
Allow custom keypad button border and lettering presence

### DIFF
--- a/TOPasscodeViewController/TOPasscodeViewController.h
+++ b/TOPasscodeViewController/TOPasscodeViewController.h
@@ -94,6 +94,12 @@ NS_ASSUME_NONNULL_BEGIN
 /** Optionally change the tint color of the UI element that indicates input progress (eg the row of circles) */
 @property (nonatomic, strong, nullable) UIColor *inputProgressViewTintColor;
 
+/** Optionally enable or disable showing the border of all keypad circle buttons. **/
+@property (nonatomic, assign) BOOL keypadButtonShowBorder;
+
+/** Optionally enable or disable showing the lettering label of all keypad circle buttons. **/
+@property (nonatomic, assign) BOOL keypadButtonShowLettering;
+
 /** If the style isn't translucent, changes the tint color of the keypad circle button outlines. */
 @property (nonatomic, strong, nullable) UIColor *keypadButtonBackgroundTintColor;
 

--- a/TOPasscodeViewController/TOPasscodeViewController.m
+++ b/TOPasscodeViewController/TOPasscodeViewController.m
@@ -594,6 +594,20 @@
     self.passcodeView.keypadButtonBackgroundColor = keypadButtonBackgroundTintColor;
 }
 
+- (void)setKeypadButtonShowBorder:(BOOL)keypadButtonShowBorder
+{
+    if (!keypadButtonShowBorder) {
+        self.passcodeView.keypadView.buttonStrokeWidth = 0.0f;
+    } else {
+        self.passcodeView.keypadView.buttonStrokeWidth = 1.5f;
+    }
+}
+
+- (void)setKeypadButtonShowLettering:(BOOL)keypadButtonShowLettering
+{
+    self.passcodeView.keypadView.showLettering = keypadButtonShowLettering;
+}
+
 - (UIColor *)keypadButtonBackgroundTintColor { return self.passcodeView.keypadButtonBackgroundColor; }
 
 - (void)setKeypadButtonTextColor:(UIColor *)keypadButtonTextColor

--- a/TOPasscodeViewController/Views/Main/TOPasscodeKeypadView.m
+++ b/TOPasscodeViewController/Views/Main/TOPasscodeKeypadView.m
@@ -104,11 +104,14 @@
         TOPasscodeCircleButton *circleButton = [self makeCircleButtonWithNumber:buttonNumber letteringString:letteringString];
         [self addSubview:circleButton];
         [buttons addObject:circleButton];
+        
+        if (!self.showLettering) {
+            circleButton.buttonLabel.verticallyCenterNumberLabel = YES; // Center the digit in the middle
+        }
 
         // Hang onto the 0 button if it's the vertical one
         // And center the text
         if (i == 9) {
-            circleButton.buttonLabel.verticallyCenterNumberLabel = YES; // Center the 0 in the middle
             self.verticalZeroButton = circleButton;
 
             // Hide the button if it's not vertically laid out
@@ -304,6 +307,10 @@
         circleButton.tintColor = self.buttonBackgroundColor;
         circleButton.textColor = self.buttonTextColor;
         circleButton.highlightedTextColor = self.buttonHighlightedTextColor;
+        if (!_showLettering) {
+            circleButton.buttonLabel.letteringLabel.text = nil;
+            circleButton.buttonLabel.verticallyCenterNumberLabel = YES;
+        }
     }
 
     [self setNeedsLayout];

--- a/TOPasscodeViewControllerExample/SettingsViewController.h
+++ b/TOPasscodeViewControllerExample/SettingsViewController.h
@@ -14,6 +14,8 @@
 @property (nonatomic, copy) NSString *passcode;
 @property (nonatomic, assign) TOPasscodeType passcodeType;
 @property (nonatomic, assign) TOPasscodeViewStyle style;
+@property (nonatomic, assign) BOOL showButtonBorder;
+@property (nonatomic, assign) BOOL showButtonLettering;
 @property (nonatomic, strong) UIImage *wallpaperImage;
 
 @property (nonatomic, copy) void (^doneButtonTappedHandler)(void);

--- a/TOPasscodeViewControllerExample/SettingsViewController.m
+++ b/TOPasscodeViewControllerExample/SettingsViewController.m
@@ -74,6 +74,7 @@ TOPasscodeSettingsViewControllerDelegate>
         case 0: return nil;
         case 1: return @"Passcode Display Style";
         case 2: return @"Choose Wallpaper";
+        case 3: return @"Passcode Keypad Button Style";
         default: break;
     }
 
@@ -81,16 +82,22 @@ TOPasscodeSettingsViewControllerDelegate>
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-    return 3;
+    return 4;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return section == 1 ? 4 : 1;
+    if (section == 1) {
+        return 4;
+    } else if (section == 3) {
+        return 2;
+    } else {
+        return 1;
+    }
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (indexPath.section < 2) { return 44.0f; }
+    if (indexPath.section != 2) { return 44.0f; }
 
     return 280.0f;
 }
@@ -128,6 +135,25 @@ TOPasscodeSettingsViewControllerDelegate>
 
         cell.textLabel.text = cellText;
     }
+    else if (indexPath.section == 3) {
+        NSString *cellText = nil;
+        
+        switch (indexPath.row) {
+            case 0:
+                cellText = @"Show Border";
+                cell.accessoryType = self.showButtonBorder ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+                break;
+            case 1:
+                cellText = @"Show Lettering";
+                cell.accessoryType = self.showButtonLettering ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+                break;
+            default:
+                break;
+        }
+        
+        cell.detailTextLabel.text = nil;
+        cell.textLabel.text = cellText;
+    }
     else {
         cell.textLabel.text = nil;
         cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
@@ -154,7 +180,7 @@ TOPasscodeSettingsViewControllerDelegate>
         settingsController.requireCurrentPasscode = YES;
         [self.navigationController pushViewController:settingsController animated:YES];
     }
-    else {
+    else if (indexPath.section == 2) {
         __weak typeof(self) weakSelf = self;
         UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
         UIImage *pasteboardImage = pasteboard.image;
@@ -181,6 +207,25 @@ TOPasscodeSettingsViewControllerDelegate>
         [controller addAction:[UIAlertAction actionWithTitle:@"Paste Image" style:UIAlertActionStyleDefault handler:clipboardAction]];
         [controller addAction:[UIAlertAction actionWithTitle:@"Choose from Library" style:UIAlertActionStyleDefault handler:photoAction]];
         [self presentViewController:controller animated:YES completion:nil];
+    }
+    else if (indexPath.section == 3) {
+        NSIndexPath *lastIndex = [NSIndexPath indexPathForRow:self.style inSection:1];
+        UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+        
+        switch (indexPath.row) {
+            case 0:
+                self.showButtonBorder = !self.showButtonBorder;
+                cell.accessoryType = self.showButtonBorder ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+                break;
+            case 1:
+                self.showButtonLettering = !self.showButtonLettering;
+                cell.accessoryType = self.showButtonLettering ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+                break;
+            default:
+                break;
+        }
+        
+        [tableView reloadRowsAtIndexPaths:@[lastIndex, indexPath] withRowAnimation:UITableViewRowAnimationNone];
     }
 }
 

--- a/TOPasscodeViewControllerExample/ViewController.m
+++ b/TOPasscodeViewControllerExample/ViewController.m
@@ -14,6 +14,8 @@
 @interface ViewController () <TOPasscodeViewControllerDelegate>
 
 @property (nonatomic, copy) NSString *passcode;
+@property (nonatomic, assign) BOOL showButtonBorder;
+@property (nonatomic, assign) BOOL showButtonLettering;
 @property (nonatomic, assign) TOPasscodeViewStyle style;
 @property (nonatomic, assign) TOPasscodeType type;
 
@@ -32,6 +34,8 @@
     [super viewDidLoad];
 
     self.passcode = @"1234";
+    self.showButtonBorder = YES;
+    self.showButtonLettering = YES;
 
     // Enable mipmaps so the rescaled image will look properly sampled
     self.imageView.layer.minificationFilter = kCAFilterTrilinear;
@@ -51,6 +55,8 @@
     passcodeViewController.delegate = self;
     passcodeViewController.allowBiometricValidation = self.biometricsAvailable;
     passcodeViewController.biometryType = self.faceIDAvailable ? TOPasscodeBiometryTypeFaceID : TOPasscodeBiometryTypeTouchID;
+    passcodeViewController.keypadButtonShowBorder = self.showButtonBorder;
+    passcodeViewController.keypadButtonShowLettering = self.showButtonLettering;
     [self presentViewController:passcodeViewController animated:YES completion:nil];
 }
 
@@ -61,6 +67,8 @@
     controller.passcodeType = self.type;
     controller.style = self.style;
     controller.wallpaperImage = self.imageView.image;
+    controller.showButtonBorder = self.showButtonBorder;
+    controller.showButtonLettering = self.showButtonLettering;
 
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:controller];
     navController.modalPresentationStyle = UIModalPresentationFormSheet;
@@ -72,6 +80,8 @@
         weakSelf.passcode = weakController.passcode;
         weakSelf.style = weakController.style;
         weakSelf.type = weakController.passcodeType;
+        weakSelf.showButtonBorder = weakController.showButtonBorder;
+        weakSelf.showButtonLettering = weakController.showButtonLettering;
 
         [weakSelf dismissViewControllerAnimated:YES completion:nil];
     };


### PR DESCRIPTION
This PR adds two optional parameters to `TOPasscodeViewController` for controlling the presence of the border and the "ABC" lettering of the keypad circular buttons. I hope this can increase the UI design flexibility (and avoid being rejected by App Store).

![custom_border_letering](https://user-images.githubusercontent.com/7240152/37271686-d7cffdd2-260e-11e8-9006-1939b8e86992.png)

The sample app has also been updated to demonstrate the new feature.