### PR TITLE
Add NSLocalizedString to "Face ID" and "Touch ID" labels

### DIFF
--- a/TOPasscodeViewController/Supporting/TOPasscodeViewControllerConstants.h
+++ b/TOPasscodeViewController/Supporting/TOPasscodeViewControllerConstants.h
@@ -65,7 +65,7 @@ static inline BOOL TOPasscodeViewStyleIsDark(TOPasscodeViewStyle style) {
 
 static inline NSString *TOPasscodeBiometryTitleForType(TOPasscodeBiometryType type) {
     switch (type) {
-        case TOPasscodeBiometryTypeFaceID: return @"Face ID";
-        default: return @"Touch ID";
+        case TOPasscodeBiometryTypeFaceID: return NSLocalizedString(@"Face ID", @"");
+        default: return NSLocalizedString(@"Touch ID", @"");
     }
 }


### PR DESCRIPTION
Apple Localized "Face ID" & "Touch ID" to "面容 ID" & "触控 ID" in iOS 11.2 Simplified Chinese Languages version, so this PR happens.