### PR TITLE
Added 'layoutIfNeeded' when changing the title of the cancel button.

### DIFF
--- a/TOPasscodeViewController/TOPasscodeViewController.m
+++ b/TOPasscodeViewController/TOPasscodeViewController.m
@@ -456,6 +456,7 @@
     [UIView performWithoutAnimation:^{
         if (title != nil) {
             [self.cancelButton setTitle:title forState:UIControlStateNormal];
+            [self.cancelButton layoutIfNeeded];
         }
         self.cancelButton.hidden = (title == nil);
     }];


### PR DESCRIPTION
After allowCancel is set to false,

When the cancel button is displayed after entering the passcode, the title of the cancel button is changed from 'cancel' to 'delete'.

So I added a layoutIfNeeded function when the title of the cancel button changes.